### PR TITLE
Update kanban.js

### DIFF
--- a/assets/javascripts/kanban.js
+++ b/assets/javascripts/kanban.js
@@ -1,7 +1,4 @@
 $(function() {
-    // Floating table header
-    $('#kanban_table').floatThead({zIndex: 39});
-
     // Redraw table header
     $('#upper_filters').on('click',function(){
         $('#kanban_table').floatThead('reflow')
@@ -17,7 +14,12 @@ $(function() {
 
     // Override sidebar style
     $('#sidebar').css({"cssText" : "padding : 0 8px 0px 8px !important"});
-
+	
+    // Floating table header
+    $('#kanban_table').floatThead({zIndex: 39});
+    //Moved from beginning of file so that float table loads after sidebar.
+    //Placing it here, after the sidebar fixes an issue with Kanban Board overflowing to end of page until reflow.
+	
     // Initial message when no note
     var initial_string = "<table class=\"my-journal-table\"><tr><td>" + label_recent_history_is_here + "</td></tr></table>"
     $('#sidebar').html(initial_string);


### PR DESCRIPTION
Fixed a bug that resulted in overflow of Kanban board to end of page in Redmine 5 on page load (but before reflow).

On Redmine 5, the float table loaded before the sidebar, resulting in it spanning the page and drawing over the sidebar.  Loading the sidebar first in this .js file allows the float table to instead fill its intended container.